### PR TITLE
Feature/ memo CRUD api 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/swagger": "^6.1.2",
         "@nestjs/typeorm": "^9.0.1",
+        "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
         "config": "^3.3.7",
@@ -2761,6 +2762,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -10917,6 +10923,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/swagger": "^6.1.2",
     "@nestjs/typeorm": "^9.0.1",
+    "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "config": "^3.3.7",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { typeORMConfig } from './configs/typeorm.config';
+import { MemoModule } from './memo/memo.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig)],
+  imports: [TypeOrmModule.forRoot(typeORMConfig), MemoModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as config from 'config';
 import { setupSwagger } from './util/swagger';
+import { VersioningType } from '@nestjs/common';
 
 const serverConfig = config.get('server');
 
@@ -10,6 +11,14 @@ async function bootstrap() {
 
   setupSwagger(app);
   const port = serverConfig.port;
+
+  app.enableVersioning({
+    type: VersioningType.URI,
+    prefix: 'v',
+    defaultVersion: '1',
+  });
+
+  app.setGlobalPrefix('/api');
 
   await app.listen(port);
 }

--- a/src/memo/dto/authCredential.dto.ts
+++ b/src/memo/dto/authCredential.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class AuthCredentialDto {
+  @IsString()
+  readonly password: string;
+}

--- a/src/memo/dto/createMemo.dto.ts
+++ b/src/memo/dto/createMemo.dto.ts
@@ -1,0 +1,18 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateMemoDto {
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(20)
+  readonly title: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(200)
+  readonly content: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(100)
+  readonly password: string;
+}

--- a/src/memo/dto/createMemoRequest.dto.ts
+++ b/src/memo/dto/createMemoRequest.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
-export class CreateMemoDto {
+export class CreateMemoRequestDto {
   @IsNotEmpty()
   @IsString()
   @MaxLength(20)

--- a/src/memo/dto/createMemoRequest.dto.ts
+++ b/src/memo/dto/createMemoRequest.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class CreateMemoRequestDto {
   @IsNotEmpty()
@@ -13,6 +13,6 @@ export class CreateMemoRequestDto {
 
   @IsNotEmpty()
   @IsString()
-  @MaxLength(100)
+  @MinLength(6)
   readonly password: string;
 }

--- a/src/memo/dto/memoResponse.dto.ts
+++ b/src/memo/dto/memoResponse.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class memoResponseDto {
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(20)
+  readonly title: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(200)
+  readonly content: string;
+}

--- a/src/memo/dto/memoResponse.dto.ts
+++ b/src/memo/dto/memoResponse.dto.ts
@@ -1,6 +1,10 @@
-import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsInt, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class MemoResponseDto {
+  @IsNotEmpty()
+  @IsInt()
+  readonly memoId: number;
+
   @IsNotEmpty()
   @IsString()
   @MaxLength(20)

--- a/src/memo/dto/memoResponse.dto.ts
+++ b/src/memo/dto/memoResponse.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
-export class memoResponseDto {
+export class MemoResponseDto {
   @IsNotEmpty()
   @IsString()
   @MaxLength(20)

--- a/src/memo/entity/memo.entity.ts
+++ b/src/memo/entity/memo.entity.ts
@@ -1,5 +1,5 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
-import { memoResponseDto } from '../dto/memoResponse.dto';
+import { MemoResponseDto } from '../dto/memoResponse.dto';
 
 @Entity()
 export class Memo {
@@ -15,7 +15,7 @@ export class Memo {
   @Column({ type: 'varchar', length: 100, nullable: false })
   password: string;
 
-  toResponse(): memoResponseDto {
+  toResponse(): MemoResponseDto {
     return {
       title: this.title,
       content: this.content,

--- a/src/memo/entity/memo.entity.ts
+++ b/src/memo/entity/memo.entity.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { memoResponseDto } from '../dto/memoResponse.dto';
 
 @Entity()
 export class Memo {
@@ -13,4 +14,11 @@ export class Memo {
 
   @Column({ type: 'varchar', length: 100, nullable: false })
   password: string;
+
+  toResponse(): memoResponseDto {
+    return {
+      title: this.title,
+      content: this.content,
+    };
+  }
 }

--- a/src/memo/entity/memo.entity.ts
+++ b/src/memo/entity/memo.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Memo {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 25, nullable: false })
+  title: string;
+
+  @Column({ type: 'varchar', length: 250, nullable: false })
+  content: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: false })
+  password: string;
+}

--- a/src/memo/entity/memo.entity.ts
+++ b/src/memo/entity/memo.entity.ts
@@ -17,6 +17,7 @@ export class Memo {
 
   toResponse(): MemoResponseDto {
     return {
+      memoId: this.id,
       title: this.title,
       content: this.content,
     };

--- a/src/memo/entity/memo.entity.ts
+++ b/src/memo/entity/memo.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { MemoResponseDto } from '../dto/memoResponse.dto';
 
 @Entity()
@@ -14,6 +21,15 @@ export class Memo {
 
   @Column({ type: 'varchar', length: 100, nullable: false })
   password: string;
+
+  @CreateDateColumn()
+  createAt: Date;
+
+  @UpdateDateColumn()
+  updateAt: Date;
+
+  @DeleteDateColumn()
+  deleteAt: Date;
 
   toResponse(): MemoResponseDto {
     return {

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('memo')
+export class MemoController {}

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -1,12 +1,14 @@
 import {
   Body,
   Controller,
+  DefaultValuePipe,
   Delete,
   Get,
   Param,
   ParseIntPipe,
   Post,
   Put,
+  Query,
   UsePipes,
   ValidationPipe,
   Version,
@@ -60,5 +62,13 @@ export class MemoController {
     @Body() authCredentialDto: AuthCredentialDto,
   ): void {
     this.memoservice.deleteMemo(id, authCredentialDto);
+  }
+
+  @Version('2')
+  @Get('/')
+  findAllMemoPage(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+  ): Promise<MemoResponseDto[]> {
+    return this.memoservice.findAllMemoPage(page);
   }
 }

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -9,6 +9,7 @@ import {
   Put,
   UsePipes,
   ValidationPipe,
+  Version,
 } from '@nestjs/common';
 import { get } from 'http';
 import { AuthCredentialDto } from './dto/authCredential.dto';
@@ -16,10 +17,11 @@ import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
 import { MemoResponseDto } from './dto/memoResponse.dto';
 import { MemoService } from './memo.service';
 
-@Controller('api/memos')
+@Controller({ path: '/memos', version: ['1', '2'] })
 export class MemoController {
   constructor(private readonly memoservice: MemoService) {}
 
+  @Version('1')
   @Post('/')
   @UsePipes(ValidationPipe)
   createMemo(
@@ -28,16 +30,19 @@ export class MemoController {
     return this.memoservice.createMemo(createMemoDto);
   }
 
+  @Version('1')
   @Get('/')
   findAllMemo(): Promise<MemoResponseDto[]> {
     return this.memoservice.findAllMemo();
   }
 
+  @Version('1')
   @Get('/:id')
   findMemo(@Param('id', ParseIntPipe) id: number): Promise<MemoResponseDto> {
     return this.memoservice.findMemo(id);
   }
 
+  @Version('1')
   @Put('/:id')
   @UsePipes(ValidationPipe)
   updateMemo(
@@ -47,6 +52,7 @@ export class MemoController {
     return this.memoservice.updateMemo(id, createMemoRequestDto);
   }
 
+  @Version('1')
   @Delete('/:id')
   @UsePipes(ValidationPipe)
   deleteMemo(

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -1,4 +1,23 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
+import { memoResponseDto } from './dto/memoResponse.dto';
+import { MemoService } from './memo.service';
 
-@Controller('memo')
-export class MemoController {}
+@Controller('api/memos')
+export class MemoController {
+  constructor(private readonly memoservice: MemoService) {}
+
+  @Post('/')
+  @UsePipes(ValidationPipe)
+  createMemo(
+    @Body() createMemoDto: CreateMemoRequestDto,
+  ): Promise<memoResponseDto> {
+    return this.memoservice.createMemo(createMemoDto);
+  }
+}

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Param,
   Post,
   UsePipes,
   ValidationPipe,
@@ -26,5 +27,10 @@ export class MemoController {
   @Get('/')
   findAllMemo(): Promise<MemoResponseDto[]> {
     return this.memoservice.findAllMemo();
+  }
+
+  @Get('/:id')
+  findMemo(@Param('id') id: number): Promise<MemoResponseDto> {
+    return this.memoservice.findMemo(id);
   }
 }

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Post,
+  Put,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -32,5 +33,13 @@ export class MemoController {
   @Get('/:id')
   findMemo(@Param('id') id: number): Promise<MemoResponseDto> {
     return this.memoservice.findMemo(id);
+  }
+
+  @Put('/:id')
+  updateMemo(
+    @Param('id') id: number,
+    @Body() createMemoRequestDto: CreateMemoRequestDto,
+  ): Promise<MemoResponseDto> {
+    return this.memoservice.updateMemo(id, createMemoRequestDto);
   }
 }

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  ParseIntPipe,
   Post,
   Put,
   UsePipes,
@@ -33,21 +34,23 @@ export class MemoController {
   }
 
   @Get('/:id')
-  findMemo(@Param('id') id: number): Promise<MemoResponseDto> {
+  findMemo(@Param('id', ParseIntPipe) id: number): Promise<MemoResponseDto> {
     return this.memoservice.findMemo(id);
   }
 
   @Put('/:id')
+  @UsePipes(ValidationPipe)
   updateMemo(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() createMemoRequestDto: CreateMemoRequestDto,
   ): Promise<MemoResponseDto> {
     return this.memoservice.updateMemo(id, createMemoRequestDto);
   }
 
   @Delete('/:id')
+  @UsePipes(ValidationPipe)
   deleteMemo(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() authCredentialDto: AuthCredentialDto,
   ): void {
     this.memoservice.deleteMemo(id, authCredentialDto);

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -1,10 +1,12 @@
 import {
   Body,
   Controller,
+  Get,
   Post,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import { get } from 'http';
 import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
 import { memoResponseDto } from './dto/memoResponse.dto';
 import { MemoService } from './memo.service';
@@ -19,5 +21,10 @@ export class MemoController {
     @Body() createMemoDto: CreateMemoRequestDto,
   ): Promise<memoResponseDto> {
     return this.memoservice.createMemo(createMemoDto);
+  }
+
+  @Get('/')
+  findAllMemo(): Promise<memoResponseDto[]> {
+    return this.memoservice.findAllMemo();
   }
 }

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { get } from 'http';
 import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
-import { memoResponseDto } from './dto/memoResponse.dto';
+import { MemoResponseDto } from './dto/memoResponse.dto';
 import { MemoService } from './memo.service';
 
 @Controller('api/memos')
@@ -19,12 +19,12 @@ export class MemoController {
   @UsePipes(ValidationPipe)
   createMemo(
     @Body() createMemoDto: CreateMemoRequestDto,
-  ): Promise<memoResponseDto> {
+  ): Promise<MemoResponseDto> {
     return this.memoservice.createMemo(createMemoDto);
   }
 
   @Get('/')
-  findAllMemo(): Promise<memoResponseDto[]> {
+  findAllMemo(): Promise<MemoResponseDto[]> {
     return this.memoservice.findAllMemo();
   }
 }

--- a/src/memo/memo.controller.ts
+++ b/src/memo/memo.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Post,
@@ -9,6 +10,7 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { get } from 'http';
+import { AuthCredentialDto } from './dto/authCredential.dto';
 import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
 import { MemoResponseDto } from './dto/memoResponse.dto';
 import { MemoService } from './memo.service';
@@ -41,5 +43,13 @@ export class MemoController {
     @Body() createMemoRequestDto: CreateMemoRequestDto,
   ): Promise<MemoResponseDto> {
     return this.memoservice.updateMemo(id, createMemoRequestDto);
+  }
+
+  @Delete('/:id')
+  deleteMemo(
+    @Param('id') id: number,
+    @Body() authCredentialDto: AuthCredentialDto,
+  ): void {
+    this.memoservice.deleteMemo(id, authCredentialDto);
   }
 }

--- a/src/memo/memo.module.ts
+++ b/src/memo/memo.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MemoController } from './memo.controller';
+import { MemoService } from './memo.service';
+
+@Module({
+  controllers: [MemoController],
+  providers: [MemoService]
+})
+export class MemoModule {}

--- a/src/memo/memo.module.ts
+++ b/src/memo/memo.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Memo } from './entity/memo.entity';
 import { MemoController } from './memo.controller';
 import { MemoService } from './memo.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Memo])],
   controllers: [MemoController],
-  providers: [MemoService]
+  providers: [MemoService],
 })
 export class MemoModule {}

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MemoService {}

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
 import { Memo } from './entity/memo.entity';
 import * as bcrypt from 'bcryptjs';
-import { memoResponseDto } from './dto/memoResponse.dto';
+import { MemoResponseDto } from './dto/memoResponse.dto';
 
 @Injectable()
 export class MemoService {
@@ -15,7 +15,7 @@ export class MemoService {
 
   async createMemo(
     createMemoDto: CreateMemoRequestDto,
-  ): Promise<memoResponseDto> {
+  ): Promise<MemoResponseDto> {
     const { title, content, password } = createMemoDto;
     const salt = await bcrypt.genSalt();
     const hashedPassword = await bcrypt.hash(password, salt);
@@ -31,10 +31,10 @@ export class MemoService {
     return creatMemo.toResponse();
   }
 
-  async findAllMemo(): Promise<memoResponseDto[]> {
+  async findAllMemo(): Promise<MemoResponseDto[]> {
     const result: Memo[] = await this.memoRepository.find();
 
-    const response: memoResponseDto[] = [];
+    const response: MemoResponseDto[] = [];
     result.forEach((element) => {
       response.push(element.toResponse());
     });

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
@@ -38,6 +38,18 @@ export class MemoService {
     result.forEach((element) => {
       response.push(element.toResponse());
     });
+
+    return response;
+  }
+
+  async findMemo(id: number): Promise<MemoResponseDto> {
+    const findMemo: Memo = await this.memoRepository.findOneBy({ id });
+
+    if (!findMemo) {
+      throw new NotFoundException(`${id}번 메모가 존재하지 않습니다.`);
+    }
+
+    const response: MemoResponseDto = findMemo.toResponse();
 
     return response;
   }

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -9,6 +9,7 @@ import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
 import { Memo } from './entity/memo.entity';
 import * as bcrypt from 'bcryptjs';
 import { MemoResponseDto } from './dto/memoResponse.dto';
+import { AuthCredentialDto } from './dto/authCredential.dto';
 
 @Injectable()
 export class MemoService {
@@ -82,5 +83,24 @@ export class MemoService {
     const result = updateMemo.toResponse();
 
     return result;
+  }
+
+  async deleteMemo(
+    id: number,
+    authCredentialDto: AuthCredentialDto,
+  ): Promise<void> {
+    const findMemo: Memo = await this.memoRepository.findOneBy({ id });
+
+    if (!findMemo) {
+      throw new NotFoundException(`${id}번 메모가 존재하지 않습니다.`);
+    }
+
+    if (
+      !(await bcrypt.compare(authCredentialDto.password, findMemo.password))
+    ) {
+      throw new UnauthorizedException('비밀번호가 일치하지 않습니다.');
+    }
+
+    await this.memoRepository.softDelete(id);
   }
 }

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -1,4 +1,33 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateMemoRequestDto } from './dto/createMemoRequest.dto';
+import { Memo } from './entity/memo.entity';
+import * as bcrypt from 'bcryptjs';
+import { memoResponseDto } from './dto/memoResponse.dto';
 
 @Injectable()
-export class MemoService {}
+export class MemoService {
+  constructor(
+    @InjectRepository(Memo)
+    private readonly memoRepository: Repository<Memo>,
+  ) {}
+
+  async createMemo(
+    createMemoDto: CreateMemoRequestDto,
+  ): Promise<memoResponseDto> {
+    const { title, content, password } = createMemoDto;
+    const salt = await bcrypt.genSalt();
+    const hashedPassword = await bcrypt.hash(password, salt);
+
+    const memo = this.memoRepository.create({
+      title,
+      content,
+      password: hashedPassword,
+    });
+
+    const creatMemo = await this.memoRepository.save(memo);
+
+    return creatMemo.toResponse();
+  }
+}

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -30,4 +30,15 @@ export class MemoService {
 
     return creatMemo.toResponse();
   }
+
+  async findAllMemo(): Promise<memoResponseDto[]> {
+    const result: Memo[] = await this.memoRepository.find();
+
+    const response: memoResponseDto[] = [];
+    result.forEach((element) => {
+      response.push(element.toResponse());
+    });
+
+    return response;
+  }
 }

--- a/src/memo/memo.service.ts
+++ b/src/memo/memo.service.ts
@@ -103,4 +103,21 @@ export class MemoService {
 
     await this.memoRepository.softDelete(id);
   }
+
+  async findAllMemoPage(page: number): Promise<MemoResponseDto[]> {
+    const take = 20;
+
+    const findMemoPage: Memo[] = await this.memoRepository.find({
+      take,
+      skip: (page - 1) * take,
+    });
+
+    const response: MemoResponseDto[] = [];
+
+    findMemoPage.forEach((element) => {
+      response.push(element.toResponse());
+    });
+
+    return response;
+  }
 }

--- a/src/memo/test/memo.controller.spec.ts
+++ b/src/memo/test/memo.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MemoController } from '../memo.controller';
+
+describe('MemoController', () => {
+  let controller: MemoController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MemoController],
+    }).compile();
+
+    controller = module.get<MemoController>(MemoController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/memo/test/memo.service.spec.ts
+++ b/src/memo/test/memo.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MemoService } from '../memo.service';
+
+describe('MemoService', () => {
+  let service: MemoService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MemoService],
+    }).compile();
+
+    service = module.get<MemoService>(MemoService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
memo CRUD API 구현 및 fix
- memo 작성
  - 비밀번호 사용
- memo 전체 조회
- memo_id를 사용한 memo 조회
- memo 수정
  - 비밀번호 사용 
- memo 삭제
  - 비밀번호 사용
- memo 조회
  - pagination
------------------------------------------
- api versioning
  - 기본 요구사항 api => v1
  - 선택 요구사항 api => v2
- 유효성 검사
  - controller에 pipe 추가
  - dto에 비밀번호 최소 길이 6으로 변경